### PR TITLE
🎉 New destination: Apache Hive

### DIFF
--- a/airbyte-integrations/connectors/destination-hive/.dockerignore
+++ b/airbyte-integrations/connectors/destination-hive/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!main.py
+!destination_hive
+!setup.py

--- a/airbyte-integrations/connectors/destination-hive/Dockerfile
+++ b/airbyte-integrations/connectors/destination-hive/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.9.11-alpine3.15 as base
+
+# build and load all requirements
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+# upgrade pip to the latest version
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+
+COPY setup.py ./
+# install necessary packages to a temporary folder
+RUN pip install --prefix=/install .
+RUN pip install impyla --prefix=/install .
+RUN pip install boto3 --prefix=/install .
+
+# build a clean environment
+FROM base
+WORKDIR /airbyte/integration_code
+
+# copy all loaded and built libraries to a pure basic image
+COPY --from=builder /install /usr/local
+# add default timezone settings
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+# bash is installed for more convenient debugging.
+RUN apk --no-cache add bash
+
+# copy payload code only
+COPY main.py ./
+COPY destination_hive ./destination_hive
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.1.0
+LABEL io.airbyte.name=airbyte/destination-hive

--- a/airbyte-integrations/connectors/destination-hive/README.md
+++ b/airbyte-integrations/connectors/destination-hive/README.md
@@ -1,0 +1,128 @@
+# Hive Destination
+
+This is the repository for the Hive destination connector, written in Python.
+This connector can be used to connect to Apache Hive or Cloudera Data Platform.
+For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.io/integrations/destinations/hive).
+
+## Local development
+
+### Prerequisites
+**To iterate on this connector, make sure to complete this prerequisites section.**
+
+#### Minimum Python version required `= 3.7.0`
+
+#### Build & Activate Virtual Environment and install dependencies
+From this connector directory, create a virtual environment:
+```
+python -m venv .venv
+```
+
+This will generate a virtualenv for this module in `.venv/`. Make sure this venv is active in your
+development environment of choice. To activate it from the terminal, run:
+```
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+If you are in an IDE, follow your IDE's instructions to activate the virtualenv.
+
+Note that while we are installing dependencies from `requirements.txt`, you should only edit `setup.py` for your dependencies. `requirements.txt` is
+used for editable installs (`pip install -e`) to pull in Python dependencies from the monorepo and will call `setup.py`.
+If this is mumbo jumbo to you, don't worry about it, just put your deps in `setup.py` but install using `pip install -r requirements.txt` and everything
+should work as you expect.
+
+#### Building via Gradle
+From the Airbyte repository root, run:
+```
+./gradlew :airbyte-integrations:connectors:destination-hive:build
+```
+
+#### Create credentials
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.io/integrations/destinations/hive)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `destination_hive/spec.json` file.
+Note that the `secrets` directory is gitignored by default, so there is no danger of accidentally checking in sensitive information.
+See `integration_tests/sample_config.json` for a sample config file.
+
+**If you are an Airbyte core member**, copy the credentials in Lastpass under the secret name `destination hive test creds`
+and place them into `secrets/config.json`.
+
+### Locally running the connector
+```
+python main.py spec
+python main.py check --config secrets/config.json
+python main.py discover --config secrets/config.json
+python main.py read --config secrets/config.json --catalog integration_tests/configured_catalog.json
+```
+
+### Locally running the connector docker image
+
+#### Build
+First, make sure you build the latest Docker image:
+```
+docker build . -t airbyte/destination-hive:dev
+```
+
+You can also build the connector image via Gradle:
+```
+./gradlew :airbyte-integrations:connectors:destination-hive:airbyteDocker
+```
+When building via Gradle, the docker image name and tag, respectively, are the values of the `io.airbyte.name` and `io.airbyte.version` `LABEL`s in
+the Dockerfile.
+
+#### Run
+Then run any of the connector commands as follows:
+```
+docker run --rm airbyte/destination-hive:dev spec
+docker run --rm -v $(pwd)/secrets:/secrets airbyte/destination-hive:dev check --config /secrets/config.json
+# messages.jsonl is a file containing line-separated JSON representing AirbyteMessages
+cat messages.jsonl | docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/destination-hive:dev write --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
+```
+## Testing
+   Make sure to familiarize yourself with [pytest test discovery](https://docs.pytest.org/en/latest/goodpractices.html#test-discovery) to know how your test files and methods should be named.
+First install test dependencies into your virtual environment:
+```
+pip install .[tests]
+```
+### Unit Tests
+To run unit tests locally, from the connector directory run:
+```
+python -m pytest unit_tests
+```
+
+### Integration Tests
+There are two types of integration tests: Acceptance Tests (Airbyte's test suite for all destination connectors) and custom integration tests (which are specific to this connector).
+#### Custom Integration tests
+Place custom tests inside `integration_tests/` folder, then, from the connector root, run
+```
+python -m pytest integration_tests
+```
+#### Acceptance Tests
+Coming soon: 
+
+### Using gradle to run tests
+All commands should be run from airbyte project root.
+To run unit tests:
+```
+./gradlew :airbyte-integrations:connectors:destination-hive:unitTest
+```
+To run acceptance and custom integration tests:
+```
+./gradlew :airbyte-integrations:connectors:destination-hive:integrationTest
+```
+
+## Dependency Management
+All of your dependencies should go in `setup.py`, NOT `requirements.txt`. The requirements file is only used to connect internal Airbyte dependencies in the monorepo for local development.
+We split dependencies between two groups, dependencies that are:
+* required for your connector to work need to go to `MAIN_REQUIREMENTS` list.
+* required for the testing need to go to `TEST_REQUIREMENTS` list
+
+### Publishing a new version of the connector
+You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
+1. Make sure your changes are passing unit and integration tests.
+1. Bump the connector version in `Dockerfile` -- just increment the value of the `LABEL io.airbyte.version` appropriately (we use [SemVer](https://semver.org/)).
+1. Create a Pull Request.
+1. Pat yourself on the back for being an awesome contributor.
+1. Someone from Airbyte will take a look at your PR and iterate with you to merge it into master.
+
+## Contribution
+This connector is contributed and maintained by Innovation Accelerator team at Cloudera.
+

--- a/airbyte-integrations/connectors/destination-hive/build.gradle
+++ b/airbyte-integrations/connectors/destination-hive/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'airbyte-python'
+    id 'airbyte-docker'
+}
+
+airbytePython {
+    moduleDirectory 'destination_hive'
+}

--- a/airbyte-integrations/connectors/destination-hive/destination_hive/__init__.py
+++ b/airbyte-integrations/connectors/destination-hive/destination_hive/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from .destination import DestinationHive
+
+__all__ = ["DestinationHive"]

--- a/airbyte-integrations/connectors/destination-hive/destination_hive/destination.py
+++ b/airbyte-integrations/connectors/destination-hive/destination_hive/destination.py
@@ -1,0 +1,116 @@
+from airbyte_cdk import AirbyteLogger
+from airbyte_cdk.destinations import Destination
+from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, DestinationSyncMode, Status, Type
+from datetime import datetime
+import impala.dbapi
+import impala.hiveserver2 as hs2
+import json
+from logging import getLogger
+from typing import Any, Dict, Iterable, Mapping, Optional
+from uuid import uuid4
+
+from .writer import create_hive_writer
+
+
+def establish_connection(config: json, logger: AirbyteLogger) -> hs2.HiveServer2Connection:
+    """
+    Creates a connection to Hive database using the parameters provided.
+    :param config: Json object containing db credentials.
+    :param logger: AirbyteLogger instance to print logs.
+    :return: PEP-249 compliant database Connection object.
+    """
+    logger.info("Connecting to Hive")
+    hive_conn = None
+    try:
+        if (not config["auth_type"]):
+            hive_conn = impala.dbapi.connect(
+                host=config["host"],
+                port=config["port"]
+            )
+        elif (config["auth_type"].upper() == 'LDAP'):
+            hive_conn = impala.dbapi.connect(
+                host=config["host"],
+                port=config["port"],
+                auth_mechanism='LDAP',
+                use_http_transport=config["use_http_transport"],
+                user=config["user"],
+                password=config["password"],
+                use_ssl=config["use_ssl"],
+                http_path=config["http_path"]
+            )
+    except Exception as e:
+        logger.error("Error connecting to hive", str(e))
+    return hive_conn
+
+class DestinationHive(Destination):
+    def write(
+        self, config: Mapping[str, Any], configured_catalog: ConfiguredAirbyteCatalog, input_messages: Iterable[AirbyteMessage]
+    ) -> Iterable[AirbyteMessage]:
+
+        """
+        Reads the input stream of messages, config, and catalog to write data to the destination.
+
+        This method returns an iterable (typically a generator of AirbyteMessages via yield) containing state messages received
+        in the input message stream. Outputting a state message means that every AirbyteRecordMessage which came before it has been
+        successfully persisted to the destination. This is used to ensure fault tolerance in the case that a sync fails before fully completing,
+        then the source is given the last state message output from this method as the starting point of the next sync.
+
+        :param config: dict of JSON configuration matching the configuration declared in spec.json
+        :param configured_catalog: The Configured Catalog describing the schema of the data being received and how it should be persisted in the
+                                    destination
+        :param input_messages: The stream of input messages received from the source
+        :return: Iterable of AirbyteStateMessages wrapped in AirbyteMessage structs
+        """
+
+        streams = {s.stream.name for s in configured_catalog.streams}
+        logger = getLogger("airbyte")
+        with establish_connection(config, logger) as connection:
+            writer = create_hive_writer(connection, config, logger)
+
+            for configured_stream in configured_catalog.streams:
+                if configured_stream.destination_sync_mode == DestinationSyncMode.overwrite:
+                    writer.delete_table(configured_stream.stream.name)
+                    logger.info(f"Stream {configured_stream.stream.name} is wiped.")
+                writer.create_raw_table(configured_stream.stream.name)
+
+            for message in input_messages:
+                if message.type == Type.STATE:
+                    yield message
+                elif message.type == Type.RECORD:
+                    data = message.record.data
+                    stream = message.record.stream
+                    # Skip unselected streams
+                    if stream not in streams:
+                        logger.debug(f"Stream {stream} was not present in configured streams, skipping")
+                        continue
+                    writer.queue_write_data(stream, str(uuid4()), datetime.now(), json.dumps(data))
+
+            # Flush any leftover messages
+            writer.flush()
+
+    def check(self, logger: AirbyteLogger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
+        """
+        Tests if the input configuration can be used to successfully connect to the destination with the needed permissions
+            e.g: if a provided API token or password can be used to connect and write to the destination.
+
+        :param logger: Logging object to display debug/info/error to the logs
+            (logs will not be accessible via airbyte UI if they are not passed to this logger)
+        :param config: Json object containing the configuration of this destination, content of this json is as specified in
+        the properties of the spec.json file
+
+        :return: AirbyteConnectionStatus indicating a Success or Failure
+        """
+
+        try:
+            with establish_connection(config, logger) as connection:
+                # We can only verify correctness of connection parameters on execution
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+                    print(cursor.fetchall())
+                    cursor.close()
+                # Test access to the bucket, if S3 strategy is used
+                create_hive_writer(connection, config, logger)
+
+            return AirbyteConnectionStatus(status=Status.SUCCEEDED)
+        except Exception as e:
+            return AirbyteConnectionStatus(status=Status.FAILED, message=f"An exception occurred: {repr(e)}")

--- a/airbyte-integrations/connectors/destination-hive/destination_hive/spec.json
+++ b/airbyte-integrations/connectors/destination-hive/destination_hive/spec.json
@@ -1,0 +1,109 @@
+{
+  "documentationUrl": "https://docs.airbyte.io/integrations/destinations/hive",
+  "supported_destination_sync_modes": [
+    "overwrite", "append", "append_dedup"
+  ],
+  "supportsIncremental": true,
+  "supportsDBT": true,
+  "supportsNormalization": true,
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Destination Hive",
+    "type": "object",
+    "required": ["host", "port", "loading_method"],
+    "additionalProperties": true,
+    "properties": {
+      "host": {
+        "type": "string",
+        "description": "Host name"
+      },
+      "port": {
+        "type": "integer",
+        "description": "Port number"
+      },
+      "auth_type": {
+        "type": "string",
+        "description": "LDAP, Kerberos"
+      },
+      "use_http_transport": {
+        "type": "string",
+        "description": "Use HTTP Transport"
+      },
+      "user": {
+        "type": "string",
+        "description": "User"
+      },
+      "password": {
+        "type": "string",
+        "description": "Password",
+        "airbyte_secret": true
+      },
+      "use_ssl": {
+        "type": "string",
+        "description": "Use SSL"
+      },
+      "http_path": {
+        "type": "string",
+        "description": "HTTP path"
+      },
+      "loading_method": {
+        "type": "object",
+        "title": "Loading Method",
+        "description": "Loading method used to select the way data will be uploaded to Hive",
+        "oneOf": [
+          {
+            "title": "SQL Inserts",
+            "additionalProperties": false,
+            "required": ["method"],
+            "properties": {
+              "method": {
+                "type": "string",
+                "const": "SQL"
+              }
+            }
+          },
+          {
+            "title": "External Table via S3",
+            "additionalProperties": false,
+            "required": [
+              "method",
+              "s3_bucket",
+              "s3_region",
+              "aws_key_id",
+              "aws_key_secret"
+            ],
+            "properties": {
+              "method": {
+                "type": "string",
+                "const": "S3"
+              },
+              "s3_bucket": {
+                "type": "string",
+                "title": "S3 bucket name",
+                "description": "The name of the S3 bucket."
+              },
+              "s3_region": {
+                "type": "string",
+                "title": "S3 region name",
+                "description": "Region name of the S3 bucket.",
+                "examples": ["us-east-1"]
+              },
+              "aws_key_id": {
+                "type": "string",
+                "title": "AWS Key ID",
+                "airbyte_secret": true,
+                "description": "AWS access key granting read and write access to S3."
+              },
+              "aws_key_secret": {
+                "type": "string",
+                "title": "AWS Key Secret",
+                "airbyte_secret": true,
+                "description": "Corresponding secret part of the AWS Key"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/airbyte-integrations/connectors/destination-hive/destination_hive/writer.py
+++ b/airbyte-integrations/connectors/destination-hive/destination_hive/writer.py
@@ -1,0 +1,278 @@
+from airbyte_cdk import AirbyteLogger
+import boto3
+from boto3.s3.transfer import TransferConfig
+from collections import defaultdict
+from datetime import datetime
+import impala.dbapi
+import impala.hiveserver2 as hs2
+import json
+from logging import getLogger
+from time import time
+from typing import Any, Dict, Iterable, Mapping, Optional
+from uuid import uuid4
+
+class HiveWriter:
+    """
+    Base class for shared writer logic.
+    """
+
+    flush_interval = 1000
+
+    def __init__(self, connection: hs2.HiveServer2Connection, config: Mapping[str, Any], logger: AirbyteLogger) -> None:
+        """
+        :param connection: Impyla hive connection class with established connection
+            to the databse.
+        """
+        self.connection = connection
+        self._buffer = defaultdict(list)
+        self._values = 0
+        self.logger = logger
+
+    def create_raw_table(self, name: str):
+        """
+        Create the resulting airbyte_raw table.
+
+        :param name: table name to create.
+        """
+        query = f"""
+        CREATE TABLE IF NOT EXISTS `airbyte_raw_{name}` (
+            `airbyte_ab_id` STRING,
+            `airbyte_emitted_at` STRING,
+            `airbyte_data` STRING,
+            PRIMARY KEY (`airbyte_ab_id`) disable novalidate
+        )
+        """
+        self.logger.info(query)
+        cursor = self.connection.cursor()
+        cursor.execute(query)
+        cursor.close()
+
+    def delete_table(self, name: str) -> None:
+        """
+        Delete the resulting table.
+        Primarily used in Overwrite strategy to clean up previous data.
+
+        :param name: table name to delete.
+        """
+        cursor = self.connection.cursor()
+        query = f"DROP TABLE IF EXISTS `airbyte_raw_{name}`"
+        self.logger.info(query)
+        cursor.execute(query)
+
+
+    def queue_write_data(self, stream_name: str, id: str, time: datetime, record: str) -> None:
+        """
+        Queue up data in a buffer in memory before writing to the database.
+        When flush_interval is reached data is persisted.
+
+        :param stream_name: name of the stream for which the data corresponds.
+        :param id: unique identifier of this data row.
+        :param time: time of writing.
+        :param record: string representation of the json data payload.
+        """
+        self._buffer[stream_name].append((id, time, record))
+        self._values += 1
+        if self._values == self.flush_interval:
+            self._flush()
+
+    def _flush(self):
+        """
+        Stub for the intermediate data flush that's triggered during the
+        buffering operation.
+        """
+        raise NotImplementedError()
+
+    def flush(self):
+        """
+        Stub for the data flush at the end of writing operation.
+        """
+        raise NotImplementedError()
+
+
+class HiveS3Writer(HiveWriter):
+    """
+    Data writer using the S3 strategy. Data is buffered in memory
+    before being flushed to S3 in .parquet format. At the end of
+    the operation data is written to Hive databse from S3, allowing
+    greater ingestion speed.
+    """
+
+    flush_interval = 100000
+
+    def __init__(self, connection: hs2.HiveServer2Connection, config: Mapping[str, Any], logger: AirbyteLogger) -> None:
+        """
+        :param connection: Impyla hive connection class with established connection
+            to the databse.
+        :param s3_bucket: Intermediate bucket to store the data files before writing them to Hive.
+            Has to be created and accessible.
+        :param access_key: AWS Access Key ID that has read/write/delete permissions on the files in the bucket.
+        :param secret_key: Corresponding AWS Secret Key.
+        :param s3_region: S3 region. Best to keep this the same as Hive database region. Default us-east-1.
+        """
+        super().__init__(connection, config, logger)
+        self.s3_bucket = config["s3_bucket"]
+        self.key_id = config["aws_key_id"]
+        self.secret_key = config["aws_key_secret"]
+        self.s3_region = config["s3_region"]
+
+        self._updated_tables = set()
+        self.s3_unique_dir = f"airbyte_output/{int(time())}_{uuid4()}"
+        self.s3_unique_path = f"{self.s3_bucket}/{self.s3_unique_dir}"
+
+        self.boto_session = boto3.Session(
+            aws_access_key_id = self.key_id,
+            aws_secret_access_key = self.secret_key
+            )
+        self.boto_client = self.boto_session.client('s3')
+
+    def __del__(self):
+        try:
+            self.connection.cursor().close()
+        except Exception as e:
+            self.logger.error("Error closing connection", e)
+
+    def create_external_table(self, name: str):
+        """
+        Create the resulting airbyte_raw table.
+
+        :param name: table name to create.
+        """
+        cursor = self.connection.cursor()
+
+        query = f"DROP TABLE IF EXISTS ex_airbyte_raw_{name}"
+        self.logger.info(query)
+        cursor.execute(query)
+
+        query = f"""
+        CREATE EXTERNAL TABLE IF NOT EXISTS ex_airbyte_raw_{name} (
+            `airbyte_ab_id` STRING,
+            `airbyte_emitted_at` STRING,
+            `airbyte_data` STRING
+        )
+        ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.JsonSerDe'
+        STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+        OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+        LOCATION 's3a://{self.s3_unique_path}/{name}/'
+        TBLPROPERTIES ( 'classification'='json')
+        """
+        self.logger.info(query)
+        cursor.execute(query)
+
+
+    def ingest_data(self, name: str) -> None:
+        """
+        Write data from External Table to the airbyte_raw table effectively
+        persisting data in Hive.
+
+        :param name: Stream name from which the table name is derived.
+        """
+        query = f"""
+            INSERT INTO TABLE `airbyte_raw_{name}`
+            SELECT airbyte_ab_id, airbyte_emitted_at, airbyte_data FROM ex_airbyte_raw_{name}
+        """
+        self.logger.info(query)
+        cursor = self.connection.cursor()
+        cursor.execute(query)
+
+    def cleanup(self, name: str) -> None:
+        """
+        Clean intermediary External tables and wipe the S3 folder.
+
+        :param name: Stream name from which the table name is derived.
+        """
+        cursor = self.connection.cursor()
+        query = f"DROP TABLE IF EXISTS ex_airbyte_raw_{name}"
+        self.logger.info(query)
+        cursor.execute(query)
+        self.logger.info(f"deleting s3 file {self.s3_unique_path}/{name}/file")
+        self.boto_client.delete_object(
+            Bucket=self.s3_bucket, 
+            Key=f"{self.s3_unique_dir}/{name}/file"
+        )
+
+    def _flush(self) -> None:
+        """
+        Intermediate data flush that's triggered during the
+        buffering operation. Uploads data stored in memory to S3.
+        """
+        self.logger.info("flushing")
+        for table, data in self._buffer.items():
+            self.logger.info(table)
+            ss = ''
+            for row in data:
+                (key, ts, payload) = row
+                js = {}
+                js["airbyte_ab_id"] = key
+                js["airbyte_emitted_at"] = str(ts)
+                js["airbyte_data"] = payload
+                # TODO: Fix inefficient way of accumulating rows into a string
+                ss += json.dumps(js) + "\n"
+
+            response = self.boto_client.put_object(
+                Bucket=self.s3_bucket,
+                Key=f"{self.s3_unique_dir}/{table}/file",
+                Body=ss.encode())
+            self.logger.info(f"response = {response}")
+        # Update tables
+        self._updated_tables.update(self._buffer.keys())
+        self._buffer.clear()
+        self._values = 0
+
+    def flush(self) -> None:
+        """
+        Flush any leftover data after ingestion and write from S3 to Hive.
+        Intermediate data on S3 and External Table will be deleted after write is complete.
+        """
+        self._flush()
+        for table in self._updated_tables:
+            self.create_raw_table(table)
+            self.create_external_table(table)
+            self.ingest_data(table)
+            self.cleanup(table)
+
+class HiveSQLWriter(HiveWriter):
+    """
+    Data writer using the SQL writing strategy. Data is buffered in memory
+    and flushed using INSERT INTO SQL statement. This is less effective strategy
+    better suited for testing and small data sets.
+    """
+
+    flush_interval = 1000
+
+    def __init__(self, connection: hs2.HiveServer2Connection, config: Mapping[str, Any], logger: AirbyteLogger) -> None:
+        """
+        :param connection: Impyla hive connection class with established connection
+            to the databse.
+        """
+        super().__init__(connection, config, logger)
+
+    def _flush(self) -> None:
+        """
+        Intermediate data flush that's triggered during the
+        buffering operation. Writes data stored in memory via SQL commands.
+        """
+        cursor = self.connection.cursor()
+        # id, written_at, data
+        for table, data in self._buffer.items():
+            cursor.execute(f"INSERT INTO TABLE airbyte_raw_{table} VALUES (?, ?, ?)", parameters_seq=data)
+        self._buffer.clear()
+        self._values = 0
+
+    def flush(self) -> None:
+        """
+        Final data flush after all data has been written to memory.
+        """
+        self._flush()
+
+def create_hive_writer(connection: hs2.HiveServer2Connection, config: Mapping[str, Any], logger: AirbyteLogger) -> HiveWriter:
+    if config["loading_method"]["method"] == "S3":
+        logger.info("Using S3 to stage data")
+        writer = HiveS3Writer(
+            connection,
+            config["loading_method"],
+            logger
+        )
+    else:
+        logger.info("Using the SQL writing strategy")
+        writer = HiveSQLWriter(connection, config, logger)
+    return writer

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/config.json
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/config.json
@@ -1,0 +1,12 @@
+{
+  "host": "myhost",
+  "port": 1111,
+  "loading_method": {
+    "method": "S3",
+    "s3_bucket": "sample_bucket",
+    "s3_region": "us-east-1",
+    "aws_key_id": "yyy",
+    "aws_key_secret": "yyy"
+  }
+}
+

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/config_s3.json
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/config_s3.json
@@ -1,0 +1,17 @@
+{
+  "host": "XXX",
+  "port": 443,
+  "auth_type": "LDAP",
+  "use_ssl": "true",
+  "use_http_transport": "true",
+  "http_path": "hive-env/cdp-proxy-api/hive",
+  "user": "XXX",
+  "password": "XXX",
+  "loading_method": {
+    "method": "S3",
+    "s3_bucket": "datalake",
+    "s3_region": "us-east-1",
+    "aws_key_id": "XXXXXXX",
+    "aws_key_secret": "XXXXXXX"
+  }
+}

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/config_sql.json
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/config_sql.json
@@ -1,0 +1,8 @@
+{
+  "host": "myhost",
+  "port": 1111,
+  "loading_method": {
+    "method": "SQL"
+  }
+}
+

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/configured_catalog.json
@@ -1,0 +1,39 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "airbyte_acceptance_table",
+        "supported_sync_modes": ["full_refresh"],
+        "source_defined_cursor": false,
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "column1": {
+              "type": "string"
+            },
+            "column2": {
+              "type": "number"
+            },
+            "column3": {
+              "type": "string",
+              "format": "datetime",
+              "airbyte_type": "timestamp_without_timezone"
+            },
+            "column4": {
+              "type": "number"
+            },
+            "column5": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    }
+  ]
+}
+

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/integration_test.py
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/integration_test.py
@@ -1,0 +1,159 @@
+import json, logging
+from typing import Any, Dict, List, Mapping
+
+import pytest
+from airbyte_cdk import AirbyteLogger
+from airbyte_cdk.models import (
+    AirbyteMessage,
+    AirbyteRecordMessage,
+    AirbyteStateMessage,
+    AirbyteStream,
+    ConfiguredAirbyteCatalog,
+    ConfiguredAirbyteStream,
+    DestinationSyncMode,
+    Status,
+    SyncMode,
+    Type,
+)
+from destination_hive import DestinationHive
+from destination_hive.destination import establish_connection
+
+from logging import getLogger
+
+
+@pytest.fixture(name="config")
+def config_fixture() -> Mapping[str, Any]:
+    with open("secrets/config.json", "r") as f:
+        return json.loads(f.read())
+
+
+@pytest.fixture(name="configured_catalog")
+def configured_catalog_fixture() -> ConfiguredAirbyteCatalog:
+    stream_schema = {"type": "object", "properties": {"string_col": {"type": "str"}, "int_col": {"type": "integer"}}}
+
+    append_stream = ConfiguredAirbyteStream(
+        stream=AirbyteStream(name="append_stream", json_schema=stream_schema, supported_sync_modes=[SyncMode.incremental]),
+        sync_mode=SyncMode.incremental,
+        destination_sync_mode=DestinationSyncMode.append,
+    )
+
+    overwrite_stream = ConfiguredAirbyteStream(
+        stream=AirbyteStream(name="overwrite_stream", json_schema=stream_schema, supported_sync_modes=[SyncMode.incremental]),
+        sync_mode=SyncMode.incremental,
+        destination_sync_mode=DestinationSyncMode.overwrite,
+    )
+
+    return ConfiguredAirbyteCatalog(streams=[append_stream, overwrite_stream])
+
+
+@pytest.fixture(autouse=True)
+def teardown(config: Mapping):
+    yield
+    client = establish_connection(config, getLogger('airbyte'))
+    cursor = client.cursor()
+    cursor.close()
+
+
+@pytest.fixture(name="client")
+def client_fixture(config):
+    return establish_connection(config, getLogger('airbyte'))
+
+
+def test_check_valid_config(config: Mapping):
+    outcome = DestinationHive().check(logging.getLogger('airbyte'), config)
+    assert outcome.status == Status.SUCCEEDED
+
+
+def test_check_invalid_config():
+    outcome = DestinationHive().check(logging.getLogger('airbyte'), {"bucket_id": "not_a_real_id"})
+    assert outcome.status == Status.FAILED
+
+
+def _state(data: Dict[str, Any]) -> AirbyteMessage:
+    return AirbyteMessage(type=Type.STATE, state=AirbyteStateMessage(data=data))
+
+
+def _record(stream: str, str_value: str, int_value: int) -> AirbyteMessage:
+    return AirbyteMessage(
+        type=Type.RECORD, record=AirbyteRecordMessage(stream=stream, data={"str_col": str_value, "int_col": int_value}, emitted_at=0)
+    )
+
+
+def retrieve_records(stream_name: str, client) -> List[AirbyteRecordMessage]:
+    cursor = client.cursor()
+    sql = f"select * from airbyte_raw_{stream_name}"
+    cursor.execute(sql)
+    all_records = cursor.fetchall()
+    out = []
+    for record in all_records:
+        # key = record[0]
+        # stream = key.split("__ab__")[0]
+        value = json.loads(record[2])
+        out.append(_record(stream_name, value["str_col"], value["int_col"]))
+    return out
+
+def retrieve_all_records(client) -> List[AirbyteRecordMessage]:
+    """retrieves and formats all records in databend as Airbyte messages"""
+    overwrite_stream = "overwrite_stream"
+    append_stream = "append_stream"
+    overwrite_out = retrieve_records(overwrite_stream, client)
+    append_out = retrieve_records(append_stream, client)
+    return overwrite_out + append_out
+
+def test_write(config: Mapping, configured_catalog: ConfiguredAirbyteCatalog, client):
+    """
+    This test verifies that:
+        1. writing a stream in "overwrite" mode overwrites any existing data for that stream
+        2. writing a stream in "append" mode appends new records without deleting the old ones
+        3. The correct state message is output by the connector at the end of the sync
+    """
+    tear_down(client)
+
+    append_stream, overwrite_stream = configured_catalog.streams[0].stream.name, configured_catalog.streams[1].stream.name
+    first_state_message = _state({"state": "1"})
+    first_record_chunk = [_record(append_stream, str(i), i) for i in range(5)] + [_record(overwrite_stream, str(i), i) for i in range(5)]
+
+    second_state_message = _state({"state": "2"})
+    second_record_chunk = [_record(append_stream, str(i), i) for i in range(5, 10)] + [
+        _record(overwrite_stream, str(i), i) for i in range(5, 10)
+    ]
+
+    destination = DestinationHive()
+
+    expected_states = [first_state_message, second_state_message]
+    output_states = list(
+        destination.write(
+            config, configured_catalog, [*first_record_chunk, first_state_message, *second_record_chunk, second_state_message]
+        )
+    )
+    assert expected_states == output_states, "Checkpoint state messages were expected from the destination"
+
+    expected_records = [_record(append_stream, str(i), i) for i in range(10)] + [_record(overwrite_stream, str(i), i) for i in range(10)]
+    records_in_destination = retrieve_all_records(client)
+    assert len(expected_records) == len(records_in_destination), "Records in destination should match records expected"
+
+    # After this sync we expect the append stream to have 15 messages and the overwrite stream to have 5
+    third_state_message = _state({"state": "3"})
+    third_record_chunk = [_record(append_stream, str(i), i) for i in range(10, 15)] + [
+        _record(overwrite_stream, str(i), i) for i in range(10, 15)
+    ]
+
+    output_states = list(destination.write(config, configured_catalog, [*third_record_chunk, third_state_message]))
+    assert [third_state_message] == output_states
+
+    records_in_destination = retrieve_all_records(client)
+    expected_records = [_record(append_stream, str(i), i) for i in range(15)] + [
+        _record(overwrite_stream, str(i), i) for i in range(10, 15)
+    ]
+    assert len(expected_records) == len(records_in_destination)
+
+    tear_down(client)
+
+
+def tear_down(client):
+    overwrite_stream = "overwrite_stream"
+    append_stream = "append_stream"
+    cursor = client.cursor()
+    cursor.execute(f"DROP table if exists airbyte_raw_{overwrite_stream}")
+    cursor.execute(f"DROP table if exists airbyte_raw_{append_stream}")
+

--- a/airbyte-integrations/connectors/destination-hive/integration_tests/messages.jsonl
+++ b/airbyte-integrations/connectors/destination-hive/integration_tests/messages.jsonl
@@ -1,0 +1,3 @@
+{"type": "RECORD", "record": {"stream": "airbyte_acceptance_table", "data": {"column1": "my_value", "column2": 221, "column3": "2021-01-01T20:10:22", "column4": 1.214, "column5": [1,2,3]}, "emitted_at": 1626172757000}}
+{"type": "RECORD", "record": {"stream": "airbyte_acceptance_table", "data": {"column1": "my_value2", "column2": 222, "column3": "2021-01-02T22:10:22", "column5": [1,2,null]}, "emitted_at": 1626172757000}}
+

--- a/airbyte-integrations/connectors/destination-hive/main.py
+++ b/airbyte-integrations/connectors/destination-hive/main.py
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+import sys
+
+from destination_hive import DestinationHive
+
+if __name__ == "__main__":
+    DestinationHive().run(sys.argv[1:])

--- a/airbyte-integrations/connectors/destination-hive/requirements.txt
+++ b/airbyte-integrations/connectors/destination-hive/requirements.txt
@@ -1,0 +1,3 @@
+-e .
+impyla
+boto3

--- a/airbyte-integrations/connectors/destination-hive/secrets_sample/config.json
+++ b/airbyte-integrations/connectors/destination-hive/secrets_sample/config.json
@@ -1,0 +1,18 @@
+{
+  "host": "host.com"
+  "port": 443,
+  "auth_type": "LDAP",
+  "use_ssl": "true",
+  "use_http_transport": "true",
+  "http_path": "hive",
+  "user": ""
+  "password": ""
+  "loading_method": {
+    "method": "S3",
+    "s3_bucket": "bucket-name"
+    "s3_region": "us-east-1",
+    "aws_key_id": "",
+    "aws_key_secret": "",
+  }
+}
+

--- a/airbyte-integrations/connectors/destination-hive/setup.py
+++ b/airbyte-integrations/connectors/destination-hive/setup.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022 Airbyte, Inc., all rights reserved.
+#
+
+
+from setuptools import find_packages, setup
+
+MAIN_REQUIREMENTS = [
+    "airbyte-cdk",
+]
+
+TEST_REQUIREMENTS = ["pytest~=6.1"]
+
+setup(
+    name="destination_hive",
+    description="Destination implementation for Hive.",
+    author="Airbyte",
+    author_email="contact@airbyte.io",
+    packages=find_packages(),
+    install_requires=MAIN_REQUIREMENTS,
+    package_data={"": ["*.json"]},
+    extras_require={
+        "tests": TEST_REQUIREMENTS,
+    },
+)

--- a/airbyte-integrations/connectors/destination-hive/unit_tests/hive_connect.py
+++ b/airbyte-integrations/connectors/destination-hive/unit_tests/hive_connect.py
@@ -1,0 +1,56 @@
+from impala.dbapi import connect
+import json
+import logging
+import sys
+
+def run_query(cursor, query):
+    print(query)
+    try:
+        res = cursor.execute(query)
+        print(res)
+        if (res is None):
+            try:
+                rows = cursor.fetchall()
+                print(rows)
+            except Exception as e:
+                print(e)
+        return
+    except Exception as e:
+        print(e)
+
+
+if __name__ == "__main__":
+
+    if (len(sys.argv) != 3):
+        logging.error("Usage: python {} <secrets/config.json> <query-string>".format(sys.argv[0]))
+        sys.exit(1)
+
+    config_file = sys.argv[1]
+    query = sys.argv[2]
+
+    secrets = None
+
+    try:
+        f = open(config_file)
+        secrets = json.load(f)
+        f.close()
+    except Exception as e:
+        logging.error('Error reading secrets file', e)
+        sys.exit(1)
+
+    conn = connect(
+        host = secrets["host"],
+        port = secrets["port"],
+        auth_mechanism = secrets["auth_type"],
+        use_ssl = (True if secrets["use_ssl"] == "true" else False),
+        use_http_transport = (True if secrets["use_http_transport"] == "true" else False),
+        http_path = secrets["http_path"],
+        user = secrets["user"],
+        password = secrets["password"])
+
+    cursor = conn.cursor()
+
+    run_query(cursor, query)
+
+    cursor.close()
+    conn.close()

--- a/airbyte-integrations/connectors/destination-hive/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-hive/unit_tests/unit_test.py
@@ -1,0 +1,53 @@
+from typing import Any, Union
+from unittest.mock import ANY, MagicMock, call, patch
+
+from destination_hive.writer import HiveSQLWriter
+from pytest import fixture, mark
+
+from logging import getLogger
+
+
+@fixture
+def client() -> MagicMock:
+    return MagicMock()
+
+
+@fixture
+def sql_writer(client: MagicMock) -> HiveSQLWriter:
+    return HiveSQLWriter(client, {}, getLogger('airbyte'))
+
+
+def test_sql_default(sql_writer: HiveSQLWriter) -> None:
+    assert len(sql_writer._buffer) == 0
+    assert sql_writer.flush_interval == 1000
+
+
+@mark.parametrize("writer", ["sql_writer"])
+def test_sql_create(client: MagicMock, writer: Union[HiveSQLWriter], request: Any) -> None:
+    writer = request.getfixturevalue(writer)
+    expected_query = """
+        CREATE FACT TABLE IF NOT EXISTS _airbyte_raw_dummy (
+            _airbyte_ab_id TEXT,
+            _airbyte_emitted_at TIMESTAMP,
+            _airbyte_data TEXT
+        )
+        PRIMARY INDEX _airbyte_ab_id
+        """
+    writer.create_raw_table("dummy")
+
+
+def test_data_buffering(sql_writer: HiveSQLWriter) -> None:
+    sql_writer.queue_write_data("dummy", "id1", 20200101, '{"key": "value"}')
+    sql_writer._buffer["dummy"][0] == ("id1", 20200101, '{"key": "value"}')
+    assert len(sql_writer._buffer["dummy"]) == 1
+    assert len(sql_writer._buffer.keys()) == 1
+    sql_writer.queue_write_data("dummy", "id2", 20200102, '{"key2": "value2"}')
+    sql_writer._buffer["dummy"][0] == ("id2", 20200102, '{"key2": "value2"}')
+    assert len(sql_writer._buffer["dummy"]) == 2
+    assert len(sql_writer._buffer.keys()) == 1
+    sql_writer.queue_write_data("dummy2", "id3", 20200103, '{"key3": "value3"}')
+    sql_writer._buffer["dummy"][0] == ("id3", 20200103, '{"key3": "value3"}')
+    assert len(sql_writer._buffer["dummy"]) == 2
+    assert len(sql_writer._buffer["dummy2"]) == 1
+    assert len(sql_writer._buffer.keys()) == 2
+

--- a/docs/integrations/destinations/hive.md
+++ b/docs/integrations/destinations/hive.md
@@ -1,0 +1,79 @@
+# Apache Hive
+
+This page guides you through the process of setting up the Apache Hive destination connector.
+
+## Prerequisites
+
+This Apache Hive destination connector has two replication strategies:
+
+1. SQL: Replicates data via SQL INSERT queries. This leverages [Impyla](https://github.com/cloudera/impyla/tree/master/impala) to execute queries directly on Apache Hive [Engines](https://hive.apache.org). **Not recommended for production workloads as this does not scale well**.
+
+2. S3: Replicates data by first uploading data to an S3 bucket, creating an External Table and writing into a final Raw Table. This is the recommended loading approach for large amounts of data. Requires an S3 bucket and credentials in addition to Apache Hive credentials.
+
+Airbyte automatically picks an approach depending on the given configuration - if S3 configuration is present, Airbyte will use the S3 strategy.
+
+For S3 strategy:
+
+```
+      "host": {
+        "type": "string",
+        "description": "Host name"
+      },
+      "port": {
+        "type": "integer",
+        "description": "Port number"
+      },
+      "auth_type": {
+        "type": "string",
+        "description": "LDAP, Kerberos"
+      },
+      "use_http_transport": {
+        "type": "string",
+        "description": "Use HTTP Transport"
+      },
+      "user": {
+        "type": "string",
+        "description": "User"
+      },
+      "password": {
+        "type": "string",
+        "description": "Password"
+      },
+      "use_ssl": {
+        "type": "string",
+        "description": "Use SSL"
+      },
+      "http_path": {
+        "type": "string",
+        "description": "HTTP path"
+      },
+```
+
+## Setup guide
+
+## Supported sync modes
+
+The Apache Hive destination connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts/#connection-sync-mode):
+- Full Refresh
+- Incremental - Append Sync
+
+
+## Connector-specific features & highlights
+
+
+### Output schema
+
+Each stream will be output into its own row in Apache Hive. Each table will contain 3 columns:
+
+* `airbyte_ab_id`: a uuid assigned by Airbyte to each event that is processed. The column type in Apache Hive is `STRING`.
+* `airbyte_emitted_at`: a timestamp representing when the event was pulled from the data source. The column type in Apache Hive is `STRING`.
+* `airbyte_data`: a json blob representing the event data. The column type in Apache Hive is `STRING` but can be be parsed with Hive's JSON functions.
+
+
+## Changelog
+
+| Version | Date       | Pull Request | Subject |
+|:--------|:-----------| :-----       | :------ |
+| 0.1.0  | 2022-10-18 | | New Destination: Apache Hive |
+| 0.1.1  | 2022-11-29 | | Code Clean up and Public PR |
+


### PR DESCRIPTION
## What
Add Apache Hive destination connector.

## How
Add a new destination for Apache Hive written using Python CDK. 
Currently supported loading methods are: SQL and S3.

## Recommended reading order
1. `spec.json`
2. `destination.py`
3. `writer.py`

## 🚨 User Impact 🚨
No breaking changes, only new destination adapter.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.

<strong>New Connector</strong>

### Community member or Airbyter

- [X] **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [X] Secrets in the connector's spec are annotated with `airbyte_secret`
- [X] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [X] Code reviews completed
- [ ] Documentation updated
    - [X] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [X] `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - [ ] `docs/integrations/README.md`
    - [ ] `airbyte-integrations/builds.md`
- [X] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- [ ] Create a non-forked branch based on this PR and test the below items on it
- [ ] Build is successful
- [ ] If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).
- [ ] [`/test connector=connectors/<name>` command](https://docs.airbyte.io/connector-development#updating-an-existing-connector) is passing
- [ ] New Connector version released on Dockerhub by running the `/publish` command described [here](https://docs.airbyte.io/connector-development#updating-an-existing-connector)
- [ ] After the connector is published, connector added to connector index as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)
- [ ] Seed specs have been re-generated by building the platform and committing the changes to the seed spec files, as described [here](https://docs.airbyte.io/connector-development#publishing-a-connector)

</details>

## Tests

<details><summary><strong>Unit</strong></summary>

Run:
<pre>
python -m pytest -vv unit_tests
</pre>

Output:
<pre>
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.9.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/ganesh.venkateshwara/code/lab/airbyte/airbyte-integrations/connectors/destination-hive/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/ganesh.venkateshwara/code/lab/airbyte, configfile: pytest.ini
collected 3 items                                                                                                                                                                            

unit_test.py::test_sql_default PASSED
unit_test.py::test_sql_create[sql_writer] {"type": "LOG", "log": {"level": "INFO", "message": "\n        CREATE TABLE IF NOT EXISTS `airbyte_raw_dummy` (\n            `airbyte_ab_id` STRING,\n            `airbyte_emitted_at` STRING,\n            `airbyte_data` STRING,\n            PRIMARY KEY (`airbyte_ab_id`) disable novalidate\n        )\n        "}}
PASSED
unit_test.py::test_data_buffering PASSED

===================================================================================== 3 passed in 0.35s ======================================================================================
</pre>

</details>

<details><summary><strong>Integration</strong></summary>

Test Connection:
<pre>
docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/destination-hive:dev check --config /secrets/config.json
</pre>

Output:
<pre>
{"type": "LOG", "log": {"level": "INFO", "message": "Connecting to Hive"}}
[(1,)]
{"type": "LOG", "log": {"level": "INFO", "message": "Using S3 to stage data"}}
{"type": "CONNECTION_STATUS", "connectionStatus": {"status": "SUCCEEDED"}}
</pre>

Test destination writing to hive:

<pre>
cat integration_tests/messages.jsonl | docker run -a stdin -a stdout -a stderr --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests -i airbyte/destination-hive:dev write --config /secrets/config.json --catalog /integration_tests/configured_catalog.json 
</pre>

Output:
<pre>
{"type": "LOG", "log": {"level": "INFO", "message": "Begin writing to the destination..."}}
{"type": "LOG", "log": {"level": "INFO", "message": "Connecting to Hive"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Using S3 to stage data"}}
{"type": "LOG", "log": {"level": "INFO", "message": "DROP TABLE IF EXISTS `airbyte_raw_airbyte_acceptance_table`"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Stream airbyte_acceptance_table is wiped."}}
{"type": "LOG", "log": {"level": "INFO", "message": "\n        CREATE TABLE IF NOT EXISTS `airbyte_raw_airbyte_acceptance_table` (\n            `airbyte_ab_id` STRING,\n            `airbyte_emitted_at` STRING,\n            `airbyte_data` STRING,\n            PRIMARY KEY (`airbyte_ab_id`) disable novalidate\n        )\n        "}}
{"type": "LOG", "log": {"level": "INFO", "message": "ignoring input which can't be deserialized as Airbyte Message: \n"}}
{"type": "LOG", "log": {"level": "INFO", "message": "flushing"}}
{"type": "LOG", "log": {"level": "INFO", "message": "airbyte_acceptance_table"}}
{"type": "LOG", "log": {"level": "INFO", "message": "response = {'ResponseMetadata': {'RequestId': 'FMT4CVHYW31J0343', 'HostId': 'WXJHe38vk0emc93/bh4VJEH5Xvt3s3H51b4nUQtjYQR6XGTUppaMu9BVQORV3FGUETdYLBj9slI=', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amz-id-2': 'WXJHe38vk0emc93/bh4VJEH5Xvt3s3H51b4nUQtjYQR6XGTUppaMu9BVQORV3FGUETdYLBj9slI=', 'x-amz-request-id': 'FMT4CVHYW31J0343', 'date': 'Mon, 28 Nov 2022 06:51:40 GMT', 'etag': '\"31177e336ce0ca26ab97f65b93548f91\"', 'server': 'AmazonS3', 'content-length': '0'}, 'RetryAttempts': 0}, 'ETag': '\"31177e336ce0ca26ab97f65b93548f91\"'}"}}
{"type": "LOG", "log": {"level": "INFO", "message": "\n        CREATE TABLE IF NOT EXISTS `airbyte_raw_airbyte_acceptance_table` (\n            `airbyte_ab_id` STRING,\n            `airbyte_emitted_at` STRING,\n            `airbyte_data` STRING,\n            PRIMARY KEY (`airbyte_ab_id`) disable novalidate\n        )\n        "}}
{"type": "LOG", "log": {"level": "INFO", "message": "DROP TABLE IF EXISTS ex_airbyte_raw_airbyte_acceptance_table"}}
{"type": "LOG", "log": {"level": "INFO", "message": "\n        CREATE EXTERNAL TABLE IF NOT EXISTS ex_airbyte_raw_airbyte_acceptance_table (\n            `airbyte_ab_id` STRING,\n            `airbyte_emitted_at` STRING,\n            `airbyte_data` STRING\n        )\n        ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.JsonSerDe'\n        STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'\n        OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'\n        LOCATION 's3a://cia-development-datalake/airbyte_output/1669618281_7bd6da18-7263-42c4-9e23-a359e9c522a6/airbyte_acceptance_table/'\n        TBLPROPERTIES ( 'classification'='json')\n        "}}
{"type": "LOG", "log": {"level": "INFO", "message": "\n            INSERT INTO TABLE `airbyte_raw_airbyte_acceptance_table`\n            SELECT airbyte_ab_id, airbyte_emitted_at, airbyte_data FROM ex_airbyte_raw_airbyte_acceptance_table\n        "}}
{"type": "LOG", "log": {"level": "INFO", "message": "DROP TABLE IF EXISTS ex_airbyte_raw_airbyte_acceptance_table"}}
{"type": "LOG", "log": {"level": "INFO", "message": "deleting s3 file cia-development-datalake/airbyte_output/1669618281_7bd6da18-7263-42c4-9e23-a359e9c522a6/airbyte_acceptance_table/file"}}
{"type": "LOG", "log": {"level": "INFO", "message": "Writing complete."}}
</pre>

Run:
<pre>
python -m pytest integration_tests -vv
</pre>

Log redacted output:
<pre>
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/ganesh.venkateshwara/code/lab/airbyte/airbyte-integrations/connectors/destination-hive/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/ganesh.venkateshwara/code/lab/airbyte, configfile: pytest.ini
collected 3 items

integration_tests/integration_test.py::test_check_valid_config PASSED
integration_tests/integration_test.py::test_check_invalid_config PASSED
integration_tests/integration_test.py::test_write PASSED

======================== 3 passed in 247.64s (0:04:07) =========================
</pre>

</details>

<details><summary><strong>Acceptance</strong></summary>

*Put your acceptance tests output here.*

</details>
